### PR TITLE
Copilot docs fixes

### DIFF
--- a/docs/concepts/copilot.md
+++ b/docs/concepts/copilot.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 :::caution
-Prophecy Data Copilot is a Public Beta release and is constantly evolving to meet the needs of our customers. This document is current as of Prophecy Release 3.1. As with all applications that interface with Large Language Models (LLMs), Data Copilot can generate results that are incorrect and/or misleading. Data Copilot is available for all customers using Prophecy’s managed Public SaaS offering.
+Data Copilot is available for all customers using Prophecy’s managed Public SaaS offering.
 :::
 
 ### Building Models and Pipelines with Prophecy’s Data Copilot
@@ -33,19 +33,24 @@ Prophecy Data Copilot is a Public Beta release and is constantly evolving to mee
 
 Prophecy Data Copilot provides suggestions from an AI model as you develop your data Pipelines. You can view and incorporate suggestions directly within the Prophecy visual editor and code editor. Data Copilot makes suggestions for your entire Pipeline, for a single Gem (transformation), and even for individual expressions within each Gem.
 
-### Text to build Pipelines
+### Text to Pipelines
 
-Get started quickly by typing your query into the text box. Prophecy Data Copilot can generate a new Pipeline or edit an existing Pipeline.
+Get started on a new Pipeline quickly by typing your query into the text box and Data Copilot will generate a new Pipeline or modify an existing one.
 
-#### Start a Pipeline
+#### Start a new Pipeline
 
 ![Start a Pipeline](img/copilot_text_to_Pipeline.png)
 
-Data Copilot can assist with starting a Pipeline. Just **(1) type a prompt with English text,** such as “Which customers shipped the largest orders this year?” **(2) Data Copilot will use metadata** from the accessible Datasets, seeds, models, Pipelines, etc. to create a Knowledge Graph. Using the Knowledge Graph, text prompt, and a selected LLM, **(3) Data Copilot creates a Pipeline.** This Pipeline is accessible in the visual editor as well as the code editor. The user can explore the individual components, **(4) keep or reject the Pipeline,** and interactively execute.
+Data Copilot can assist with starting a Pipeline. For example:
+
+1. Type a prompt with English text, such as `Which customers shipped the largest orders this year?`
+2. Data Copilot will use metadata from the accessible Datasets, Seeds, Models, Pipelines, etc. to create a Knowledge Graph.
+3. Data Copilot uses OpenAI's language model to create the Pipeline based on the text prompt, with the Knowledge Graph as the context. This Pipeline is accessible in the visual editor as well as the code editor.
+4. The user can **keep** or **reject** the suggested Pipeline and interactively execute it to see the results.
 
 #### Modify an existing Pipeline
 
-The user can also call Data Copilot to modify an existing Pipeline. Select which Gem should be the starting point for modifications downstream, and type a new text prompt. Data Copilot will suggest a new sequence of data transformations following from the selected starting point.
+The user can also call Data Copilot to modify an existing Pipeline. Select which Gem should be the starting point for modifications downstream, and type a new text prompt. Data Copilot will suggest a new sequence of data transformations after the selected starting point.
 
 ### Next-transformation suggestions
 
@@ -53,15 +58,28 @@ The user can also call Data Copilot to modify an existing Pipeline. Select which
 
 ![Suggest Gems](img/copilot_next_suggestion.png)
 
-Data Copilot can suggest the next transformation in a series. Here, the user **(1) selects a Dataset** of interest, then **(2) Data Copilot suggests Datasets** which are frequently used with the selected Dataset. **(3) Data Copilot then suggests a next transformation,** in this case a Join Gem.
+Data Copilot can suggest the next transformation in a series. In this example:
+
+1. The User selects a Dataset of interest
+2. Data Copilot suggests Datasets which are frequently used with the selected Dataset.
+3. Data Copilot then suggests a next transformation, in this case, a Join Gem.
 
 #### Suggest Expressions
 
 ![Suggest expressions](img/copilot_next_suggestion_expression.png)
 
-At the more granular level, Data Copilot can suggest expressions within Gems. Simply **(1) type an English text prompt** and **(2) Data Copilot generates a code expression** for a particular column. **(3) Click to accept** the code expression or try again with a different prompt. Data Copilot’s returns are non-deterministic, so a retry can return a different expression. **(4) Run** the Pipeline upto and including this Gem, and observe the resulting **data preview sample.**
+At the more granular level, Data Copilot can suggest expressions within Gems. Within our [advanced Expression Builder](/docs/low-code-spark/expression-builder.md) a User can:
 
-### Auto Documentation - Coming soon
+1. Type an English text prompt
+2. Data Copilot generates a code expression for a particular column.
+3. Click to accept the code expression or try again with a different prompt. Data Copilot’s returns are non-deterministic, so a retry can return a different expression.
+4. Run the Pipeline up to and including this Gem, and observe the resulting **data preview sample.**
+
+### Auto Documentation
+
+:::caution
+This feature is under development and is coming soon!
+:::
 
 <div class="wistia_responsive_padding" style={{padding:'62.5% 0 0 0', position:'relative'}}>
 <div class="wistia_responsive_wrapper" style={{height:'100%',left:0,position:'absolute',top:0,width:'100%'}}>
@@ -69,9 +87,13 @@ At the more granular level, Data Copilot can suggest expressions within Gems. Si
 </div></div>
 <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 
-Understanding data assets is much easier with Data Copilot’s auto documentation, to be offered in an upcoming release. Data Copilot will deliver summary documentation suggestions for all Datasets, Pipelines, and Orchestrations. How did a Dataset change? Data Copilot will recommend a description of the change for every edit you make. How was a column computed? Data Copilot suggests a description that explains how every column generated for analytics was computed and what it represents.
+Understanding data assets is much easier with Data Copilot’s auto-documentation, to be offered in an upcoming release. Data Copilot will deliver summary documentation suggestions for all Datasets, Pipelines, and Orchestrations. How did a Dataset change? Data Copilot will recommend a description of the change for every edit you make. How was a column computed? Data Copilot suggests a plain English description that explains how every column is generated and what it represents.
 
-### Data Tests and Quality Checks - Coming soon
+### Data Tests and Quality Checks
+
+:::caution
+This feature is under development and is coming soon!
+:::
 
 <div class="wistia_responsive_padding" style={{padding:'56.25% 0 0 0', position:'relative'}}>
 <div class="wistia_responsive_wrapper" style={{height:'100%',left:0,position:'absolute',top:0,width:'100%'}}>
@@ -79,44 +101,34 @@ Understanding data assets is much easier with Data Copilot’s auto documentatio
 </div></div>
 <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 
-Unit tests and data quality checks are crucial for Pipeline and model productionization, yet many teams leave little time to develop these tests or worse, don’t build them at all. With Data Copilot, you’ll have a suggested unit test - with code provided - for Prophecy to run on every committed change. Data Copilot also suggests data quality checks based on the data profile and expectations.
-
-### Settings
-
-1. Data Copilot is available for all customers using Prophecy’s managed, Public SaaS offering. For companies who run Prophecy within their own VPC ([link](/docs/architecture/deployment/deployment.md#private-saas-customer-vpc)), admins may choose to enable or disable Data Copilot across their Prophecy Platform at deployment time.
-2. Coming soon, Prophecy Administrators will have the option to connect Prophecy Data Copilot to their private subscription OpenAI.
-3. Data Copilot is designed with simplicity in mind, with minimal configurations for the user. If there’s a setting you’d like to see, let us know!
-
-| Project Type  | Code Suggested by Copilot | Orchestration   | Features coming soon for Data Copilot                                |
-| :------------ | :------------------------ | :-------------- | -------------------------------------------------------------------- |
-| Spark (Scala) | Spark SQL                 | Databricks Jobs | Airflow, Private LLM options, AutoDoc, Data Tests and Quality Checks |
-| PySpark       | Spark SQL                 | Databricks Jobs | Airflow, Private LLM options, AutoDoc, Data Tests and Quality Checks |
-| SQL           | SQL                       | Databricks Jobs | Airflow, Private LLM options, AutoDoc, Data Tests and Quality Checks |
-
-For Spark and PySpark projects, Data Copilot suggests code written in Spark SQL, which is Apache Spark’s module for working with structured data ([link](https://spark.apache.org/docs/latest/sql-programming-guide.html)). Data co-pilot currently supports Databricks jobs, and Airflow support is coming soon.
+Unit tests and data quality checks are crucial for Pipeline and Job productionalization, yet many teams leave little time to develop these tests or worse, don’t build them at all. With Data Copilot, you’ll have one or more suggested [unit tests](/docs/low-code-spark/tests.md) that can be seamlessly integrated into your CICD process. Data Copilot will also be able to suggest data quality checks based on the data profile and expectations.
 
 ## Architecture
 
 ### Knowledge Graph
 
-Briefly, Data Copilot works by enhancing the user’s prompt using a knowledge graph.
+Data Copilot works by enhancing the user’s prompt using a knowledge graph.
 
 ![Knowledge Graph](img/copilot_knowledge_graph.png)
 
-In particular, the knowledge graph includes metadata for the Project’s entities (eg Datasets, Schemas, Seeds, Models, and Pipelines) and statistical usages of these entities. We built the knowledge graph intentionally to include metadata but not data. Individual Dataset records, for example, are not included in the knowledge graph.
+Our knowledge graph includes metadata for a Project’s entities (eg Datasets, Schemas, Seeds, Models, and Pipelines) and the statistical usages of these entities. We built the knowledge graph intentionally to include metadata but not data. Individual Dataset records, for example, are not included in the knowledge graph, only the structure.
 
 ![Architecture](img/copilot_arch.png)
 
-Prophecy sends the enhanced Prompt to OpenAI (or the user’s preferred LLM). The model will return a set of SQL or SparkSQL code, and Prophecy will verify whether this code is valid. Once Prophecy fixes the code, Prophecy generates a visual Pipeline and displays this Pipeline to the user for review.
+Prophecy sends the enhanced Prompt to OpenAI (or the user’s preferred LLM). The model will return SQL or SparkSQL code, and Prophecy will verify whether this code is valid. Once Prophecy fixes the code, Prophecy generates a visual Pipeline and displays this Pipeline to the user for review.
+
+### Language Model
+
+Data Copilot is available for all customers using Prophecy’s managed Public SaaS offering and uses the public SaaS version of OpenAI's Language model. We will be releasing support for private Language model instances in an upcoming release.
 
 ### Data Privacy
 
 The Prophecy team employs top-notch industry practices to safeguard the security of their application and maintain the privacy of customer data. Below are just a few components of our comprehensive security strategy and system structure:
 
-- Prophecy IDE is hosted on secure servers on AWS. All storage systems are encrypted, and all servers are tightly access controlled and audited. Data is encrypted in-transit at all times.
+- Prophecy **does not** store or send _anything_ from your data plane to any third-party LLM providers. Instead, Prophecy makes use of rich metadata to construct the knowledge graph. As a result, Data Copilot can interface with LLM providers while maintaining the privacy of the data itself.
+- Prophecy IDE is hosted on secure servers on AWS. All storage systems are encrypted, and all servers are tightly access controlled and audited. Data is encrypted in transit at all times.
 - Alternatively, Prophecy’s IDE can be installed within an Enterprise network as desired.
-- Prophecy’s IDE accesses your environment through a single IP address dedicated to you, allowing you to protect access to your data resources at the network level. The credentials are stored per-user, and only a fully authenticated user can access their environment.
-- Prophecy does not store or send any data to any third party LLM providers. Instead, Prophecy makes use of rich metadata to construct the knowledge graph. As a result, Data Copilot can interface with LLM providers while maintaining privacy of the data itself.
+- Prophecy’s IDE accesses your environment through a single IP address dedicated to you, allowing you to protect access to your data resources at the network level. The credentials are stored per user, and only a fully authenticated user can access their environment.
 - An annual penetration test is performed to validate Prophecy’s posture and identify vulnerabilities. Our latest penetration test report was issued in November 2022.
 - Prophecy maintains SOC-2 compliance as audited by PrescientAssurance.
 - Read more details on Prophecy’s security and compliance posture at our Security Portal [here](https://security.Prophecy.io/).
@@ -127,7 +139,7 @@ The Prophecy team employs top-notch industry practices to safeguard the security
 
 #### How is Prophecy Copilot different than Github Copilot?
 
-Github Copilot is a great tool to boost productivity and extend the reach for the coding community. However, not every problem is solved with direct coding. More importantly, users need a Copilot with some context of the interesting data.
+Github Copilot is a great tool to boost productivity and extend the reach of the coding community. However, not every problem is solved with direct coding. More importantly, users need a Copilot with some context of the interesting data.
 
 For teams of analysts, data platform providers, or line-of-business users, the pain points are not resolved by teaching every team member how to code. Data Copilot empowers less technical users because they don’t have to code. Importantly, technical and coding users benefit from Data Copilot because visual Pipelines are easier to understand, explain, and leverage. Prophecy’s Data Copilot boosts the productivity of the low-code user and the more technical coding team members.
 
@@ -137,11 +149,19 @@ Github Copilot and Prophecy Data Copilot are both excellent tools to boost produ
 
 #### Which Datasets are accessible to Prophecy Data Copilot?
 
-In Prophecy’s 3.1 release, any Dataset, Source, or Seed within a Project are accessible when Data Copilot is called from that Project. In an upcoming release this behavior will change as follows: The assets need only to be part of the linked (Databricks, Snowflake, etc) catalog. That is, if the user can access the Datasets with their token, the Datasets should appear in the Environment tab and Copilot can access them.
+In Prophecy’s 3.1 release, any Dataset, Source, or Seed within a Project are accessible when Data Copilot is called from that Project. In an upcoming release, this behavior will change as follows: The assets need only to be part of the linked (Databricks, Snowflake, etc) catalog. That is, if the user can access the Datasets with their token, the Datasets should appear in the Environment tab and Copilot can access them.
 
-#### How much will I pay for use of Prophecy Copilot?
+#### How much will I pay for Prophecy Copilot?
 
 Copilot features are included with Prophecy’s Low-Code Spark and Low-Code SQL offerings. There would be an additional cost if you chose to use a private subscription Large Language Model (LLM) service. In this case, the cost depends on (1) the number of tokens sent to the LLM provider, (2) the size of the Datasets, and (3) the number of iterations Prophecy sends requests to the LLM provider.
+
+#### Can I disable this feature for my users?
+
+For companies who run Prophecy within their [own VPC](/docs/architecture/deployment/deployment.md#private-saas-customer-vpc), admins may choose to enable or disable Data Copilot across their Prophecy Platform at deployment time.
+
+#### Can I use my own private OpenAI instance?
+
+In a future release, Administrators will have the option to connect Prophecy Data Copilot to their private subscription OpenAI.
 
 ## Try Data Copilot
 

--- a/docs/concepts/copilot.md
+++ b/docs/concepts/copilot.md
@@ -1,5 +1,5 @@
 ---
-title: Data Copilot
+title: Data Copilot (NEW!)
 id: copilot
 description: The AI assistant for data Pipelines and models
 sidebar_position: 8
@@ -46,7 +46,7 @@ Data Copilot can assist with starting a Pipeline. For example:
 1. Type a prompt with English text, such as `Which customers shipped the largest orders this year?`
 2. Data Copilot will use metadata from the accessible Datasets, Seeds, Models, Pipelines, etc. to create a Knowledge Graph.
 3. Data Copilot uses OpenAI's language model to create the Pipeline based on the text prompt, with the Knowledge Graph as the context. This Pipeline is accessible in the visual editor as well as the code editor.
-4. The user can **keep** or **reject** the suggested Pipeline and interactively execute it to see the results.
+4. The user can keep or reject the suggested Pipeline and interactively execute it to see the results.
 5. View Data Copilot's suggested changes in the visual editor.
 
 #### Modify an existing Pipeline
@@ -167,6 +167,10 @@ In a future release, Administrators will have the option to connect Prophecy Dat
 #### Can I use Data Copilot on my on-premise installation of Prophecy?
 
 Yes! Speak to your Prophecy account owner with questions.
+
+#### Does Prophecy Data Copilot support text prompts in languages other than English?
+
+While Prophecy does not actively test prompt languages other than English, the LLM providers do provide such support. Explorations of this area would be at the user discretion.
 
 ## Try Data Copilot
 

--- a/docs/concepts/copilot.md
+++ b/docs/concepts/copilot.md
@@ -9,7 +9,7 @@ tags:
   - generativeai
 ---
 
-:::caution
+:::tip
 Data Copilot is available for all customers using Prophecy’s managed Public SaaS offering.
 :::
 
@@ -47,6 +47,7 @@ Data Copilot can assist with starting a Pipeline. For example:
 2. Data Copilot will use metadata from the accessible Datasets, Seeds, Models, Pipelines, etc. to create a Knowledge Graph.
 3. Data Copilot uses OpenAI's language model to create the Pipeline based on the text prompt, with the Knowledge Graph as the context. This Pipeline is accessible in the visual editor as well as the code editor.
 4. The user can **keep** or **reject** the suggested Pipeline and interactively execute it to see the results.
+5. View Data Copilot's suggested changes in the visual editor.
 
 #### Modify an existing Pipeline
 
@@ -73,7 +74,7 @@ At the more granular level, Data Copilot can suggest expressions within Gems. Wi
 1. Type an English text prompt
 2. Data Copilot generates a code expression for a particular column.
 3. Click to accept the code expression or try again with a different prompt. Data Copilot’s returns are non-deterministic, so a retry can return a different expression.
-4. Run the Pipeline up to and including this Gem, and observe the resulting **data preview sample.**
+4. Run the Pipeline up to and including this Gem, and observe the resulting data sample.
 
 ### Auto Documentation
 
@@ -111,7 +112,7 @@ Data Copilot works by enhancing the user’s prompt using a knowledge graph.
 
 ![Knowledge Graph](img/copilot_knowledge_graph.png)
 
-Our knowledge graph includes metadata for a Project’s entities (eg Datasets, Schemas, Seeds, Models, and Pipelines) and the statistical usages of these entities. We built the knowledge graph intentionally to include metadata but not data. Individual Dataset records, for example, are not included in the knowledge graph, only the structure.
+Our knowledge graph includes metadata for a Project’s entities (eg Datasets, Schemas, Seeds, Models, and Pipelines) and the statistical usages of these entities. We built the knowledge graph intentionally to include metadata but not data. The Dataset structure is included in the knowledge graph but individual Dataset records are not.
 
 ![Architecture](img/copilot_arch.png)
 
@@ -149,11 +150,11 @@ Github Copilot and Prophecy Data Copilot are both excellent tools to boost produ
 
 #### Which Datasets are accessible to Prophecy Data Copilot?
 
-In Prophecy’s 3.1 release, any Dataset, Source, or Seed within a Project are accessible when Data Copilot is called from that Project. In an upcoming release, this behavior will change as follows: The assets need only to be part of the linked (Databricks, Snowflake, etc) catalog. That is, if the user can access the Datasets with their token, the Datasets should appear in the Environment tab and Copilot can access them.
+In Prophecy’s 3.1 release, any Dataset, Source, or Seed within a Project are accessible when Data Copilot is called from that Project. In an upcoming release, this behavior will change as follows: The assets need only to be part of the linked (Databricks, Snowflake, etc) catalog. That is, if the user can access the Datasets with their personal access token, then Datasets should appear in the Environment tab and Copilot can access them.
 
 #### How much will I pay for Prophecy Copilot?
 
-Copilot features are included with Prophecy’s Low-Code Spark and Low-Code SQL offerings. There would be an additional cost if you chose to use a private subscription Large Language Model (LLM) service. In this case, the cost depends on (1) the number of tokens sent to the LLM provider, (2) the size of the Datasets, and (3) the number of iterations Prophecy sends requests to the LLM provider.
+Copilot features are included with Prophecy’s Low-Code Spark and Low-Code SQL offerings. There would be an additional cost if you chose to use a private subscription Large Language Model (LLM) service. In this case, the cost depends on (1) the number of [word tokens](https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them) sent to the LLM provider, (2) the size of the Datasets, and (3) the number of iterations Prophecy sends requests to the LLM provider.
 
 #### Can I disable this feature for my users?
 
@@ -162,6 +163,10 @@ For companies who run Prophecy within their [own VPC](/docs/architecture/deploym
 #### Can I use my own private OpenAI instance?
 
 In a future release, Administrators will have the option to connect Prophecy Data Copilot to their private subscription OpenAI.
+
+#### Can I use Data Copilot on my on-premise installation of Prophecy?
+
+Yes! Speak to your Prophecy account owner with questions.
 
 ## Try Data Copilot
 

--- a/docs/concepts/copilot.md
+++ b/docs/concepts/copilot.md
@@ -116,7 +116,7 @@ Our knowledge graph includes metadata for a Project’s entities (eg Datasets, S
 
 ![Architecture](img/copilot_arch.png)
 
-Prophecy sends the enhanced Prompt to OpenAI (or the user’s preferred LLM). The model will return SQL or SparkSQL code, and Prophecy will verify whether this code is valid. Once Prophecy fixes the code, Prophecy generates a visual Pipeline and displays this Pipeline to the user for review.
+Prophecy sends the enhanced Prompt to OpenAI (or the user’s preferred LLM). The model will return SQL or Spark code, and Prophecy will verify whether this code is valid. Once Prophecy fixes the code, Prophecy generates a visual Pipeline and displays this Pipeline to the user for review.
 
 ### Language Model
 

--- a/docs/concepts/copilot.md
+++ b/docs/concepts/copilot.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 :::caution
-Prophecy Data Copilot is a Public Beta release and is constantly evolving to meet the needs of our customers. This document is current as of Prophecy Release 3.1. As with all applications that interface with Large Language Models (LLMs), Data Copilot can generate results which are incorrect and/or misleading.
+Prophecy Data Copilot is a Public Beta release and is constantly evolving to meet the needs of our customers. This document is current as of Prophecy Release 3.1. As with all applications that interface with Large Language Models (LLMs), Data Copilot can generate results that are incorrect and/or misleading. Data Copilot is available for all customers using Prophecy’s managed Public SaaS offering.
 :::
 
 ### Building Models and Pipelines with Prophecy’s Data Copilot
@@ -23,7 +23,11 @@ Prophecy Data Copilot is a Public Beta release and is constantly evolving to mee
 
 Prophecy’s low-code platform makes data Pipeline development faster and accessible to more users. Starting now, you’ve got an AI assistant to boost that productivity even further.
 
-We are open to feedback! Please send us an email (contact@Prophecy.io) or reach out in our Slack [community.](https://join.slack.com/t/prophecy-io-support/shared_invite/zt-moq3xzoj-~5MSJ6WPnZfz7bwsqWi8tQ)
+We are open to feedback! Please send us an email (contact@Prophecy.io) or reach out on our Slack [community.](https://join.slack.com/t/prophecy-io-support/shared_invite/zt-moq3xzoj-~5MSJ6WPnZfz7bwsqWi8tQ)
+
+:::caution
+Prophecy Data Copilot is a Public Beta release and is constantly evolving to meet the needs of our customers. This document is current as of Prophecy Release 3.1. As with all applications that interface with Large Language Models (LLMs), Data Copilot can generate results that are incorrect and/or misleading.
+:::
 
 ## Capabilities
 

--- a/docs/low-code-spark/expression-builder.md
+++ b/docs/low-code-spark/expression-builder.md
@@ -12,7 +12,7 @@ tags:
 
 To perform data analysis and manipulation, Spark has provided various functions. These functions enable users to perform various data analysis tasks on their data.
 In order to perform complex data analysis tasks, it's important to be able to construct expressions that combine the Spark functions in various ways.
-Prophecy has now made this easy with support of **Expression Builder**. Using the Spark Expression Builder can save you time and effort when constructing complex expressions, and can help you to better understand the relationships between different functions and their arguments.
+Prophecy has now made this easy with the support of **Expression Builder**. Using the Spark Expression Builder can save you time and effort when constructing complex expressions, and can help you to better understand the relationships between different functions and their arguments.
 
 <div style={{position: 'relative', 'padding-bottom': '56.25%', height: 0}}>
    <iframe src="https://www.loom.com/embed/958ccd09f1a5435fa4348be6dca3996e" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen


### PR DESCRIPTION
* Removed `Settings` section as we don't have any settings
* Removed feature matrix as it was confusing and a bit redundant
* Moved VPC-specific content to FAQ
* Clarified steps as numbered list