### PR TITLE
add some explanation about Package Builder

### DIFF
--- a/docs/concepts/models/models.md
+++ b/docs/concepts/models/models.md
@@ -10,4 +10,4 @@ tags:
   - target
 ---
 
-# Coming soon!
+Detailed documentation on **SQL Models** coming soon!

--- a/docs/concepts/models/models.md
+++ b/docs/concepts/models/models.md
@@ -9,3 +9,5 @@ tags:
   - sql
   - target
 ---
+
+# Coming soon!

--- a/docs/package-hub/package-builder/ShareableDatasets.md
+++ b/docs/package-hub/package-builder/ShareableDatasets.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-title: Shareable Datasets
+title: Build Shareable Datasets
 id: shareable-datasets
 description: Shareable Datasets within the project
 tags: []

--- a/docs/package-hub/package-builder/ShareablePipelines.md
+++ b/docs/package-hub/package-builder/ShareablePipelines.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: Shareable Pipelines
+title: Build Shareable Pipelines
 id: shareable-pipelines
 description: Shareable Pipelines within the project and to other projects
 tags: []

--- a/docs/package-hub/package-builder/ShareableSubgraphs.md
+++ b/docs/package-hub/package-builder/ShareableSubgraphs.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: Shareable Subgraphs
+title: Build Shareable Subgraphs
 id: shareable-subgraphs
 description: Sharable Subgraphs within the project and to other projects
 tags: []

--- a/docs/package-hub/package-builder/ShareableUDFs.md
+++ b/docs/package-hub/package-builder/ShareableUDFs.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-title: Shareable UDFs
+title: Build Shareable UDFs
 id: sharable-udfs
 description: Sharable UDFs within the project and to other projects
 tags: []

--- a/docs/package-hub/package-builder/gem-builder.md
+++ b/docs/package-hub/package-builder/gem-builder.md
@@ -1,11 +1,11 @@
 ---
-title: Gem Builder
+title: Build Shareable Gems
 id: Gem-builder
 description: Build custom Gems to share across teams with the Package Hub
 tags: []
 ---
 
-While Prophecy offers dozens of Gems out-of-the-box, some data practitioners want to extend this idea and create their own Gems. Incorporate your custom code into a Prophecy Gem with Prophecy’s **Gem Builder.** Then publish the Gem with the entire Project to the **[Package Hub](/docs/package-hub/package-hub.md)** or share with selected teams.
+While Prophecy offers dozens of Gems out-of-the-box, some data practitioners want to extend this idea and create their own Gems. Incorporate your custom code into a Prophecy Gem. As part of Prophecy’s **Package Builder**, publish your custom Gem with the entire Project to the **[Package Hub](/docs/package-hub/package-hub.md)** or share with selected teams.
 
 ## Quickstart
 
@@ -471,7 +471,7 @@ class LimitCode(props: PropertiesType) extends ComponentCode {
 
 ````
 
-You can go ahead and preview the component in the Gem Builder now to see how it looks. Note some Gem examples have functions defined within the apply method.
+You can go ahead and preview the component to see how it looks. Note some Gem examples have functions defined within the apply method.
 
 That’s all the code for our example Transformation, the Limit Gem. We walked through the package and import statements, parent class, and properties class. We explored the required methods dialog, validation, onChange, (de)serializeProperty. Finally we saw the Limit Gem’s component code. Now we have a basic understanding of the components needed for any Transformation Gem.
 

--- a/docs/package-hub/package-builder/package-builder.md
+++ b/docs/package-hub/package-builder/package-builder.md
@@ -5,6 +5,10 @@ description: Build packages using pipeline components
 tags: []
 ---
 
+With **Package Builder**, engineering teams gain an intuitive tool for standardized creation of packaged operations, including Pipelines, Functions, Custom Gems, and more. You can now easily reuse code and enforce best practices across your data operations, eliminating manual and error-prone processes.
+
+Create a Project with any combination of building blocks below. For example, the [custom Gem page](/docs/package-hub/package-builder/gem-builder.md) has detailed instructions on building a custom Gem within a Project. When you commit and release your Project with a version, you are now able to share the released Project as a *Package* dependency. Other teams can then re-use the components. Check out the [Package Hub](/docs/package-hub/package-hub.md) page for a deep dive on using Packages.
+
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';

--- a/docs/package-hub/package-builder/package-builder.md
+++ b/docs/package-hub/package-builder/package-builder.md
@@ -7,11 +7,13 @@ tags: []
 
 With **Package Builder**, engineering teams gain an intuitive tool for standardized creation of packaged operations, including Pipelines, Functions, Custom Gems, and more. You can now easily reuse code and enforce best practices across your data operations, eliminating manual and error-prone processes.
 
-Create a Project with any combination of building blocks below. For example, the [custom Gem page](/docs/package-hub/package-builder/gem-builder.md) has detailed instructions on building a custom Gem within a Project. When you commit and release your Project with a version, you are now able to share the released Project as a *Package* dependency. Other teams can then re-use the components. Check out the [Package Hub](/docs/package-hub/package-hub.md) page for a deep dive on using Packages.
+Create a Project with any combination of building blocks below. For example, the [custom Gem page](/docs/package-hub/package-builder/gem-builder.md) has detailed instructions on building a custom Gem within a Project. When you commit and release your Project with a version, you are now able to share the released Project as a **Package** dependency. Other teams can then re-use the components. Check out the [Package Hub](/docs/package-hub/package-hub.md) page for a deep dive on using Packages.
 
-```mdx-code-block
-import DocCardList from '@theme/DocCardList';
-import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
+## Build shareable components
 
-<DocCardList items={useCurrentSidebarCategory().items}/>
-```
+- **[Pipelines](/docs/package-hub/package-builder/ShareablePipelines.md)** in Packages can be used as templates in new or existing projects. Pass configuration variables to a template Pipeline to re-use in a new Project. For example, read/write from configured table names using a template Pipeline.
+- **[Custom Gems](/docs/package-hub/package-builder/gem-builder.md)** in Packages can be dragged and dropped into new or existing projects as you would any Gem. Configure the Custom Gem visually, execute, and view data previews.
+- **[Subgraphs](/docs/package-hub/package-builder/ShareableSubgraphs.md)** in Packages can also be used as templates in new or existing Projects, very similar to Pipelines. (A Subgraph is essentially a mini Pipeline that can be called within a Pipeline.)
+- **[User Defined Functions (UDFs)](/docs/package-hub/package-builder/ShareableUDFs.md)** are custom functions that can be re-used across projects by calling the function inside the Gem expressions. Sharing UDFs in packages is a feature that will be coming soon after the Prophecy 3.2 release.
+- **Jobs** in Packages can be used across projects as a configured instance. Sharing Jobs in Packages is a feature that will be coming soon after the Prophecy 3.2 release.
+- **[Datasets](/docs/package-hub/package-builder/ShareableDatasets.md)** in Prophecy are pointers to actual data in your data storage solution. Check this [page](/docs/package-hub/package-builder/ShareableDatasets.md) for our recommendations on sharing Datasets.

--- a/docs/package-hub/package-hub.md
+++ b/docs/package-hub/package-hub.md
@@ -11,16 +11,7 @@ Prophecy introduces **Package Hub,** which enables data practitioners to create 
 
 A Package is a versioned Project that can be shared across teams. As such, a Package can contain Pipeline templates, [custom Gems](/docs/package-hub/package-builder/gem-builder.md), functions, subgraph templates, etc - a reusable version of everything a Project contains. Package dependencies allow us to re-use components so we don’t have to rebuild them. The coding community has been using packages for ages, and finally the low-code community can take advantage of the same idea. Packages are shareable within and across teams. For extra visibility, the Package Hub is a curated selection of Packages that your teams create and publish for other users to leverage.
 
-Just include a Package as a dependency to take advantage of its contents.
-
-- **[Pipelines](/docs/package-hub/package-builder/ShareablePipelines.md)** in Packages can be used as templates in new or existing projects. Pass configuration variables to a template Pipeline to re-use in a new Project. For example, read/write from configured table names using a template Pipeline.
-- **[Custom Gems](/docs/package-hub/package-builder/gem-builder.md)** in Packages can be dragged and dropped into new or existing projects as you would any Gem. Configure the Custom Gem visually, execute, and view data previews.
-- **[Subgraphs](/docs/package-hub/package-builder/ShareableSubgraphs.md)** in Packages can also be used as templates in new or existing Projects, very similar to Pipelines. (A Subgraph is essentially a mini Pipeline that can be called within a Pipeline.)
-- **[User Defined Functions (UDFs)](/docs/package-hub/package-builder/ShareableUDFs.md)** are custom functions that can be re-used across projects by calling the function inside the Gem expressions. Sharing UDFs in packages is a feature that will be coming soon after the Prophecy 3.2 release.
-- **Jobs** in Packages can be used across projects as a configured instance. Sharing Jobs in Packages is a feature that will be coming soon after the Prophecy 3.2 release.
-- **[Datasets](/docs/package-hub/package-builder/ShareableDatasets.md)** in Prophecy are pointers to actual data in your data storage solution. Check this [page](/docs/package-hub/package-builder/ShareableDatasets.md) for our recommendations on sharing Datasets.
-
-See the sections below for step-by-step instructions on how to [use](/docs/package-hub/package-hub.md#use-a-package), [build](/docs/package-hub/package-hub.md#build-a-package), and [share](/docs/package-hub/package-hub.md#share-a-package) Packages.
+Just include a Package as a dependency to take advantage of its contents. See the sections below for step-by-step instructions on how to [use](/docs/package-hub/package-hub.md#use-a-package), [build](/docs/package-hub/package-hub.md#build-a-package), and [share](/docs/package-hub/package-hub.md#share-a-package) Packages. For those looking for a deeper dive on building packages, see the [Package Builder](/docs/package-hub/package-builder/package-builder.md) page.
 
 ## Use a package
 
@@ -106,7 +97,7 @@ When you create a new Gem, a **(1)code guide** appears. Use the guide or replace
 
 **(1)Run** the custom Gem to check whether the functionality works as expected. Click **(2)Data** to view the data input and **(3)output** preview. The `customer_id` is encrypted after our function is applied.
 
-For more details on building Packages with Custom Gems, see the [Gembuilder documentation.](/docs/package-hub/package-builder/gem-builder.md)
+Click [here](/docs/package-hub/package-builder/gem-builder.md) for a deep dive on building Packages with Custom Gems.
 
 Once you have tested your Gem in the canvas, and you are happy with both the **Gem UI Component** and **Gem Code Logic**, you will want to release a tagged version.
 


### PR DESCRIPTION
Package Builder messaging: 
* Adjusts the messaging from "Gem Builder" to use "Build Shareable Gems"
* Adjusts the messaging from "Shareable Pipelines" to use "Build Shareable Pipelines
* Same for Subgraphs, UDFs, etc.
* Moves some text from Package Hub to Package Builder page. 

Other: 
* Mentions "SQL Models" are Coming soon. 