### PR TITLE
Fixed typos on Databricks doc page

### DIFF
--- a/docs/low-code-spark/fabrics/create-a-fabric.md
+++ b/docs/low-code-spark/fabrics/create-a-fabric.md
@@ -68,12 +68,12 @@ Please refer to the below video for a step-by-step example, or learn how to conf
 
 :::note
 The Spark and Scala versions are now mandatory with recent [Release](/docs/release_notes/2023/feb2023.md#spark-and-scala-versions-are-now-required-in-livy-Fabrics).
-If you have an older Fabric which doesn't have Spark abd Scala versions present, an error (seen below) will appear when trying to attach to a cluster. Just update the Fabric from the metadata page or by clicking `Update Fabric` button (seen below).
+If you have an older Fabric which doesn't have Spark and Scala versions present, an error (seen below) will appear when trying to attach to a cluster. Just update the Fabric from the metadata page or by clicking `Update Fabric` button (seen below).
 ![Fabric_misconfigured](img/fabric_misconfigured.png)
 :::
 
 - **Job sizes** -
-  By default, you will see a Small Job size pre created. You can edit or add more Job sizes. A Job sie consists off
+  By default, you will see a Small Job size pre created. You can edit or add more Job sizes. A Job size consists of
 
   - Size of the Driver: Driver Core and Memory
   - Size of the Executor: Core and Memory for each executor


### PR DESCRIPTION
Fix multiple typos on Databricks doc page per https://app.asana.com/0/1203457878958265/1207335329386532