### PR TITLE
Fix warning callouts to caution

### DIFF
--- a/docs/SQL/gems/datasources/upload-files.md
+++ b/docs/SQL/gems/datasources/upload-files.md
@@ -54,7 +54,7 @@ You can also replace your uploaded file or delete it.
 
 You can select the database and schema for your table. For the table location, you can either create a new table or select a table you want to write your uploaded file to.
 
-:::warning
+:::caution Warning
 
 Selecting a table to write your uploaded file to deletes and re-creates the table.
 

--- a/docs/Spark/execution/databricks-clusters-behaviors.md
+++ b/docs/Spark/execution/databricks-clusters-behaviors.md
@@ -69,7 +69,7 @@ When running Pipelines and Jobs, you may be interested to know few metrics relat
 read/written, bytes read/written, total time taken and Data samples b/w components. These Dataset, Pipeline-run and
 Job-run related metrics are accumulated and stored on your data plane and can be viewed later from Prophecy UI. For more details, refer [here](./execution-metrics).
 
-:::warning
+:::caution
 These metrics are **not available** for `Shared mode` clusters (both normal workspaces and Unity catalog workspaces). You should see a proper error when trying to get historical runs of Pipelines/Jobs executed on `Shared mode` clusters.
 
 :::

--- a/docs/Spark/fabrics/dataproc.md
+++ b/docs/Spark/fabrics/dataproc.md
@@ -18,7 +18,7 @@ In the context of Spark execution engines, users have the flexibility to opt for
 
 <br/><br/>
 
-:::caution Warning
+:::caution
 Livy is required for the Fabric. Prophecy provides a script required to deploy a Dataproc Cluster.
 :::
 

--- a/docs/architecture/deployment/installation-guide.md
+++ b/docs/architecture/deployment/installation-guide.md
@@ -11,7 +11,7 @@ tags:
 Prophecy installation requires a Kubernetes cluster. Its installation and upgrades are managed by our infrastructure management plane called `Athena`.
 Athena is installed through helm chart which internally deploys Prophecy Kubernetes Operator to manage different Prophecy services.
 
-:::warning
+:::caution
 
 The following documentation pertains to the Helm installer for Prophecy version 3.3 and above. If you're considering migrating your current Helm installer chart to this version, we encourage you to reach out to the Prophecy support team for personalized assistance and guidance.
 
@@ -50,7 +50,7 @@ As mentioned above, Prophecy is installed via Helm chart called the Prophecy-ins
 1. **Platform:** Is the section used to configure the various platform components like - elastic-search, promethus, grafana, loki etc.
 1. **Version:** The Prophecy version to be deployed
 
-:::warning
+:::note
 
 Parameters marked with an asterisk(\*) are mandatory.
 

--- a/docs/architecture/deployment/private-saas/configure-audit-logs.md
+++ b/docs/architecture/deployment/private-saas/configure-audit-logs.md
@@ -15,9 +15,13 @@ tags:
 
 Prophecy offers robust support for storing audit events (logs) on two of the industry's leading cloud object stores: AWS S3, Azure Blob Storage, GCP Cloud Storage or even local persistent volume (PV). Leveraging the capabilities of these object stores, Prophecy seamlessly synchronizes and persistently stores audit events. This not only ensures the secure retention of crucial data but also facilitates streamlined tracking and in-depth analysis of user interactions and activities for enhanced operational insights.
 
-:warning: Certain [object store level configurations](./configure-object-store.md) are shared with [backup restore configurations](./configure-backup.md). Make sure to configure the [object store level configurations](./configure-object-store.md) before proceeding below.
+:::note
 
-## Usecase
+Certain [object store level configurations](./configure-object-store.md) are shared with [backup restore configurations](./configure-backup.md). Make sure to configure the [object store level configurations](./configure-object-store.md) before proceeding below.
+
+:::
+
+## Use case
 
 - The overarching objective is to comprehensively track and log every user-level action.
 - All user actions will be meticulously recorded and stored, enabling easy retrieval from a persistent storage or object store, particularly when an audit is required.

--- a/docs/architecture/deployment/private-saas/configure-backup.md
+++ b/docs/architecture/deployment/private-saas/configure-backup.md
@@ -14,9 +14,13 @@ tags:
 
 Prophecy provides a reliable backup mechanism for safeguarding all critical data utilized by the Prophecy app. Users can consistently back up essential data through their preferred object store, such as AWS S3, Azure Blob Storage, or local storage (which could be backed up by a NFS). This systematic backup process guarantees the accessibility of data for future restoration needs. Prophecy leverages the advanced capabilities of these object stores to seamlessly synchronize the backups, ensuring a robust and efficient data protection strategy.
 
-:warning: Certain [object store level configurations](./configure-object-store.md) are shared with [audit event logs configurations here](./configure-audit-logs.md). Make sure to configure the [object store level configurations](./configure-object-store.md) before proceeding below.
+:::note
 
-## Usecase
+Certain [object store level configurations](./configure-object-store.md) are shared with [audit event logs configurations here](./configure-audit-logs.md). Make sure to configure the [object store level configurations](./configure-object-store.md) before proceeding below.
+
+:::
+
+## Use case
 
 - Prophecy, by design, does not store or own any customer data or code. Instead, it focuses on maintaining essential metadata related to various projects, user-created gems, users, and team information.
 - Prophecy manages a persistence storage system, responsible for holding uncommitted changes, as well as other relevant data.
@@ -24,7 +28,11 @@ Prophecy provides a reliable backup mechanism for safeguarding all critical data
 - The current backup support always performs full backups, providing comprehensive data protection.
   This backup functionality has been available since the release of Prophecy version 3.1.2.0.
 
-:warning: Please note this doc is constantly updated with new features/options and hence it is better to always go with the latest version of Prophecy.
+:::tip
+
+Note this doc is constantly updated with new features/options and hence it is better to always go with the latest version of Prophecy.
+
+:::
 
 ## Configuration
 
@@ -42,7 +50,7 @@ To configure object store settings in the Prophecy UI, follow these steps:
 
 ### JSON format
 
-Below are JSON configurations within the Prophecy UI that need to be enabled to support this functionality. You will have to configure only the options which you require. Please make sure to maintain a JSON format mentioned below while configuring the different options.
+Below are JSON configurations within the Prophecy UI that need to be enabled to support this functionality. You will have to configure only the options which you require. Make sure to maintain a JSON format mentioned below while configuring the different options.
 
 ```
 {
@@ -69,7 +77,11 @@ There are two ways to perform backup of data. Choose either one of the below opt
 
 ### Trigger Backup API
 
-:warning: To trigger a backup/restore manually you would require a API key. [Follow the API Key generation document to generate the same](./generate-api-key) before proceeding below.
+:::note
+
+To trigger a backup/restore manually you would require a API key. [Follow the API Key generation document to generate the same](./generate-api-key) before proceeding below.
+
+:::
 
 #### Triggering a backup
 
@@ -206,7 +218,7 @@ Sample response
 
 #### Delete Backup Entry
 
-This API attempts the delete the backup data (local and upstream) and also the metadata (database entries) associated with it. Please note that in case of `enableRegularBackups` set to `true`, backups are older than `backupRetentionCount` in reverse order are garbage collected automatically.
+This API attempts the delete the backup data (local and upstream) and also the metadata (database entries) associated with it. Note that in case of `enableRegularBackups` set to `true`, backups are older than `backupRetentionCount` in reverse order are garbage collected automatically.
 
 Sample API call
 
@@ -229,18 +241,22 @@ Sample response
 
 Restore is an on-demand based overwrite of the whole configuration to reflect the state at which backup is taken.
 
-:::warning
-This API should be used with extreme caution as triggerring this will lead to loss of current state/data.
+:::danger
+This API should be used with extreme caution as triggering this will lead to loss of current state/data.
 :::
 
-Note:
+Note the following:
 
 - If backup was taken in Athena’s local Persistent Volume, it needs to be copied to Athena’s Persistent Volume in the destination cluster before the restore operation can be performed.
 - Restore operation always assumes a running destination Prophecy cluster where the data and the configuration of source cluster will be restored.
 
 ### Starting a Restore
 
-:warning: To trigger a backup/restore manually you would require a API key. [Follow the API Key generation document to generate the same](./generate-api-key) before proceeding below.
+:::note
+
+To trigger a backup/restore manually you would require a API key. [Follow the API Key generation document to generate the same](./generate-api-key) before proceeding below.
+
+:::
 
 The below API is used to trigger a store opertion. It expects one parameter which is the `timestamp` of a successful backup.
 

--- a/docs/architecture/deployment/private-saas/configure-object-store.md
+++ b/docs/architecture/deployment/private-saas/configure-object-store.md
@@ -31,7 +31,7 @@ To configure object store settings in the Prophecy UI, follow these steps:
 
 Below are JSON configurations within the Prophecy UI that need to be enabled to support this functionality. You will have to configure only the options which you require. Please make sure to maintain a JSON format mentioned below while configuring the different options.
 
-:::warning
+:::caution
 Please note that all sensitive keys are displayed in `********` format. However, you may supply the new values in normal text and save the JSON to update the keys.
 :::
 

--- a/docs/package-hub/package-builder/ShareableUDFs.md
+++ b/docs/package-hub/package-builder/ShareableUDFs.md
@@ -20,7 +20,7 @@ Please see this video for an example
       style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}}></iframe>
 </div>
 
-:::warning
+:::caution
 Please note that UDF code is only copied to Code for that Pipeline once the Pipeline is opened.
 So, if a user has edited or added UDF in a Pipeline, you might see uncommitted changes for another Pipeline whenever you open it.  
 :::


### PR DESCRIPTION
The warning callouts are mistakenly shown as danger. Using caution fixes this. I also left some caution callouts as warnings where they made sense by using ":::caution Warning".

Also edited Usecase to Use case. And fixed typos.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208012876600739