### PR TITLE
gems concept page link fix

### DIFF
--- a/docs/getting-started/concepts/gems.md
+++ b/docs/getting-started/concepts/gems.md
@@ -39,6 +39,5 @@ To start using gems in your pipelines:
 
 - Explore the available [Engineering (Spark) gems](/engineers/gems/) and [Analyst gems](/analysts/gems).
 - Add and connect various gems in your pipeline canvas.
-- Browse the [Package Hub]([Gems](docs/getting-started/concepts/gems.md) are visually-packaged parcels of code that perform specific operations on data. While Prophecy provides many gems out of the box, Prophecy also lets you create your own gems! Not only can you create new gems, but you can also share them in the [Package Hub](/engineers/package-hub) or with selected teams.
-  d) to find additional gems and components that you can use.
+- Browse the [Package Hub](/engineers/package-hub) to find additional gems and components that you can use.
 - Take a peek at our [Gem Builder](/engineers/extensibility) for an introduction to custom gems.


### PR DESCRIPTION
Went back to the original slug updates PR [here](https://github.com/SimpleDataLabsInc/prophecy-docs/pull/593/files#diff-dcc8954a9bf9ab694229f119a546b44b15f1a7582d01c41efc87802b0a9d192c) and reverted this back to the original text with the new slug.